### PR TITLE
Handle all open dependabot updates (pytest, pytest-cov, pygments)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-    "pytest~=8.0",
-    "pytest-cov~=4.1",
+    "pytest>=8,<10",
+    "pytest-cov>=4.1,<8.0",
     "flake8~=7.0",
 ]
 


### PR DESCRIPTION
## Summary

Consolidates the three open dependabot PRs into a single change to `pyproject.toml`:

- **#10 pytest**: widen constraint from `~=8.0` to `>=8,<10` (allows pytest 9.x)
- **#11 pytest-cov**: widen constraint from `~=4.1` to `>=4.1,<8.0` (allows up to 7.x)
- **#8 Pygments 2.19.2**: already satisfied by the existing `Pygments>=2.19.2` constraint on `main`, so no change is needed; this PR supersedes it.

Once merged, the three dependabot PRs can be closed.

## Test plan

- [x] `python3 -m pip install -e ".[dev]"` resolves cleanly
- [x] `python3 -m pytest` — 4 tests pass (pytest 9.0.3, pytest-cov 7.1.0, Pygments 2.20.0), 100% coverage
- [x] `flake8` — no style errors
- [ ] CI (`Python Release` workflow) passes on the PR

https://claude.ai/code/session_01Y6QwRLMEHWRqMj9t9K8mR6